### PR TITLE
Multiple database option

### DIFF
--- a/config/config.dev.php
+++ b/config/config.dev.php
@@ -10,11 +10,37 @@
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
  */
 
+//single database usage
 $env_db['hostname'] = 'localhost';
 $env_db['username'] = '';
 $env_db['password'] = '';
 $env_db['database'] = '';
 
+
+$env_config['webmaster_email'] = 'dev@domain.com';
+
+/**
+Example of multiple database usage
+$env_db['expressionengine']['hostname'] = '';
+$env_db['expressionengine']['username'] = '';
+$env_db['expressionengine']['password'] = '';
+$env_db['expressionengine']['database'] = '';
+
+$env_db['another_db']['hostname'] = '';
+$env_db['another_db']['username'] = '';
+$env_db['another_db']['password'] = '';
+$env_db['another_db']['database'] = '';
+$env_db['another_db']['dbprefix'] = '';
+$env_db['another_db']['swap_pre'] = '';
+$env_db['another_db']['dbdriver'] = 'mysql';
+$env_db['another_db']['pconnect'] = FALSE;
+$env_db['another_db']['db_debug'] = TRUE;
+$env_db['another_db']['cache_on'] = FALSE;
+$env_db['another_db']['autoinit'] = FALSE;
+$env_db['another_db']['char_set'] = 'utf8';
+$env_db['another_db']['dbcollat'] = 'utf8_general_ci';
+$env_db['another_db']['cachedir'] = '';
+*/
 
 $env_config['webmaster_email'] = 'dev@domain.com';
 

--- a/config/config.master.php
+++ b/config/config.master.php
@@ -64,7 +64,30 @@ if (isset($db['expressionengine']))
 	$env_db['cachedir'] = APPPATH . 'cache/db_cache/';
 	
 	// Merge our database setting arrays
-	$db['expressionengine'] = array_merge($db['expressionengine'], $env_db);
+	if(isset($env_db['expressionengine'])) //looks like we're dealing with multiple dbs
+	{
+		foreach($env_db AS $key => $value)
+		{
+			if(!isset($db[$key]))
+			{
+				$db[$key] = array();
+			}
+			
+			if(is_array($env_db[$key]))
+			{
+				$db[$key] = array_merge($db[$key], $env_db[$key]);
+			}
+			else
+			{
+				$db[$key] = $env_db[$key];
+			}
+		}
+	}
+	else
+	{
+		//default single DB
+		$db['expressionengine'] = array_merge($db['expressionengine'], $env_db);
+	}
 	
 	// No need to have this variable accessible for the rest of the app
 	unset($env_db);


### PR DESCRIPTION
Example usage is in config.dev.php

Instructions:
you use a multidimensional array for database credentials. Master uses "expressionengine" for the key and all others follow
Backwards compatibility with single databases is maintained.

Note: You MUST include all database config keys for additional databases (included in config.dev.php)
