### PR TITLE
Update `$env_config['show_profiler']` condition to detect new control panel URLs

### DIFF
--- a/config/config.master.php
+++ b/config/config.master.php
@@ -165,7 +165,7 @@ if (isset($config))
 	$env_config['allow_extensions']     = 'y';
 	$env_config['email_debug']          = (ENV_DEBUG) ? 'y' : 'n' ;
 	// If we're not in production show the profile on the front-end but not in the CP
-	$env_config['show_profiler']        = ( ! ENV_DEBUG OR (isset($_GET['D']) && $_GET['D'] == 'cp')) ? 'n' : 'y' ;
+	$env_config['show_profiler']        = ( ! ENV_DEBUG OR (isset($_GET['D']) && $_GET['D'] == 'cp') OR preg_match('/^\/cp/', $_SERVER['QUERY_STRING'])) ? 'n' : 'y' ;
 	// Show template debugging if we're not in production
 	$env_config['template_debugging']   = (ENV_DEBUG) ? 'y' : 'n' ;
 	/**


### PR DESCRIPTION
EE 2.8.0 introduced new CP URLs. The master config sets `$env_config['show_profiler']` to `n` if we're in the control panel. The original checks were failing with the new URLs, so this commit adds an additional check that successfully detects the new CP URLs.
