### PR TITLE
Allow control of system_on from environment configuration

### DIFF
--- a/config/config.env.php
+++ b/config/config.env.php
@@ -19,24 +19,28 @@ if ( ! defined('ENV'))
 			define('ENV', 'prod');
 			define('ENV_FULL', 'Production');
 			define('ENV_DEBUG', FALSE);
+			define('ENV_SYSTEM_ON', TRUE);
 		break;
 		
 		case 'staging.domain.com' :
 			define('ENV', 'stage');
 			define('ENV_FULL', 'Staging');
 			define('ENV_DEBUG', FALSE);
+			define('ENV_SYSTEM_ON', FALSE);
 		break;
 		
 		case 'dev.domain.com' :
 			define('ENV', 'dev');
 			define('ENV_FULL', 'Development');
 			define('ENV_DEBUG', TRUE);
+			define('ENV_SYSTEM_ON', TRUE);
 		break;
 
 		default :
 			define('ENV', 'local');
 			define('ENV_FULL', 'Local');
 			define('ENV_DEBUG', TRUE);
+			define('ENV_SYSTEM_ON', TRUE);
 		break;
 	}
 }

--- a/config/config.master.php
+++ b/config/config.master.php
@@ -161,7 +161,7 @@ if (isset($config))
 	 * These settings are helpful to have in one place
 	 * for debugging purposes
 	 */
-	$env_config['is_system_on']         = 'y';
+	$env_config['is_system_on']         = (ENV_SYSTEM_ON) ? 'y' : 'n';
 	$env_config['allow_extensions']     = 'y';
 	$env_config['email_debug']          = (ENV_DEBUG) ? 'y' : 'n' ;
 	// If we're not in production show the profile on the front-end but not in the CP

--- a/readme.textile
+++ b/readme.textile
@@ -42,6 +42,7 @@ Three constants are defined in our environment declaration file. They are:
 * @ENV@
 * @ENV_FULL@
 * @ENV_DEBUG@
+* @ENV_SYSTEM_ON@
 
 *@ENV@*
 
@@ -54,6 +55,10 @@ This is the full name of your environment. There are no requirements on this val
 *@ENV_DEBUG@*
 
 This is our boolean debug flag used frequently in our master config file. It allows us to keep debug settings "on" in specific environments. You can see how this is used in the master config file.
+
+*@ENV_SYSTEM_ON@*
+
+This allows us to switch the system on, or off, in specific environments. You can see how this is used in the environment config file.
 
 h3. Master Config file
 


### PR DESCRIPTION
This lets you managed the `$env_config['is_system_on']` variable from `config.env.php`, for example if you want to have it switched on for local development, and off for the staging server.