### PR TITLE
Remove HTTP_HOST

### DIFF
--- a/config/config.dev.php
+++ b/config/config.dev.php
@@ -2,11 +2,11 @@
 
 /**
  * Development config overrides & db credentials
- * 
+ *
  * Our database credentials and any environment-specific overrides
- * 
+ *
  * @package    Focus Lab Master Config
- * @version    2.1.1
+ * @version    2.2.0
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
  */
 

--- a/config/config.env.php
+++ b/config/config.env.php
@@ -14,29 +14,38 @@
 
 if ( ! defined('ENV'))
 {
+	$production  = 'domain.com';
+	$staging     = 'staging.domain.com';
+	$development = 'dev.domain.com';
+	$local       = 'localhost';
+
 	switch (strtolower($_SERVER['HTTP_HOST'])) {
-		case 'domain.com' :
+		case $production:
 			define('ENV', 'prod');
 			define('ENV_FULL', 'Production');
 			define('ENV_DEBUG', FALSE);
+			define('ENV_DOMAIN', $production);
 		break;
-		
-		case 'staging.domain.com' :
+
+		case $staging:
 			define('ENV', 'stage');
 			define('ENV_FULL', 'Staging');
 			define('ENV_DEBUG', FALSE);
+			define('ENV_DOMAIN', $staging);
 		break;
-		
-		case 'dev.domain.com' :
+
+		case $development:
 			define('ENV', 'dev');
 			define('ENV_FULL', 'Development');
 			define('ENV_DEBUG', TRUE);
+			define('ENV_DOMAIN', $development);
 		break;
 
-		default :
+		default:
 			define('ENV', 'local');
 			define('ENV_FULL', 'Local');
 			define('ENV_DEBUG', TRUE);
+			define('ENV_DOMAIN', $local);
 		break;
 	}
 }

--- a/config/config.env.php
+++ b/config/config.env.php
@@ -2,13 +2,13 @@
 
 /**
  * Environment Declaration
- * 
+ *
  * This switch statement sets our environment. The environment is used primarily
  * in our custom config file setup. It is also used, however, in the front-end
  * index.php file and the back-end admin.php file to set the debug mode
- * 
+ *
  * @package    Focus Lab Master Config
- * @version    2.1.1
+ * @version    2.2.0
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
  */
 

--- a/config/config.local.php
+++ b/config/config.local.php
@@ -2,12 +2,12 @@
 
 /**
  * Local config overrides & db credentials
- * 
+ *
  * Our database credentials and any environment-specific overrides
  * This file should be specific to each developer and not tracked in Git
- * 
+ *
  * @package    Focus Lab Master Config
- * @version    2.1.1
+ * @version    2.2.0
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
  */
 

--- a/config/config.master.php
+++ b/config/config.master.php
@@ -57,7 +57,7 @@ if (isset($config))
 	 * As inspired by Matt Weinberg: http://eeinsider.com/articles/multi-server-setup-for-ee-2/
 	 */
 	$protocol                          = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
-	$base_url                          = $protocol . $_SERVER['HTTP_HOST'];
+	$base_url                          = $protocol . ENV_DOMAIN;
 	$base_path                         = $_SERVER['DOCUMENT_ROOT'];
 	$system_folder                     = APPPATH . '../';
 	$images_folder                     = 'images';

--- a/config/config.master.php
+++ b/config/config.master.php
@@ -2,26 +2,26 @@
 
 /**
  * Focus Lab, LLC Master Config
- * 
+ *
  * This is the master config file for our ExpressionEngine sites
  * The settings will contain database credentials and numerous "config overrides"
  * used throughout the site. This file is used as first point of configuration
  * but there are environment-specific files as well. The idea is that the environment
  * config files contain config overrides that are specific to a single environment.
- * 
+ *
  * Some config settings are used in multiple (but not all) environments. You will
  * see the use of conditionals around the ENV constant in this file. This constant is
  * defined in ./config/config.env.php
- * 
+ *
  * All config files are stored in the ./config/ directory and this master file is "required"
  * in system/expressionengine/config/config.php and system/expressionengine/config/database.php
- * 
+ *
  * require $_SERVER['DOCUMENT_ROOT'] . '/../config/config.master.php';
- * 
+ *
  * This config setup is a combination of inspiration from Matt Weinberg and Leevi Graham
  * @link       http://eeinsider.com/articles/multi-server-setup-for-ee-2/
  * @link       http://ee-garage.com/nsm-config-bootstrap
- * 
+ *
  * @package    Focus Lab Master Config
  * @version    2.1.1
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
@@ -33,7 +33,7 @@
 // already been loaded in index.php or admin.php
 if ( ! defined('ENV'))
 {
-	require 'config.env.php'; 
+	require 'config.env.php';
 }
 
 
@@ -43,7 +43,7 @@ $env_db = $env_config = $env_global = $master_global = array();
 
 /**
  * Config override magic
- * 
+ *
  * If this equates to TRUE then we're in the config.php file
  */
 if (isset($config))
@@ -51,7 +51,7 @@ if (isset($config))
 
 	/**
 	 * Dynamic path settings
-	 * 
+	 *
 	 * Make it easy to run the site in multiple environments and not have to switch up
 	 * path settings in the database after each migration
 	 * As inspired by Matt Weinberg: http://eeinsider.com/articles/multi-server-setup-for-ee-2/
@@ -88,7 +88,7 @@ if (isset($config))
 
 	/**
 	 * Custom upload directory paths
-	 * 
+	 *
 	 * The array keys must match the ID from exp_upload_prefs
 	 */
 	// $env_config['upload_preferences'] = array(
@@ -107,23 +107,23 @@ if (isset($config))
 
 	/**
 	 * Template settings
-	 * 
+	 *
 	 * Working locally we want to reference our template files.
 	 * In staging and production we do not use flat files (for ever-so-slightly better performance)
 	 * This approach requires that we synchronize templates after each deployment of template changes
-	 * 
+	 *
 	 * For the distributed Focus Lab, LLC Master Config file this is commented out
 	 * You can enable this "feature" by uncommenting the second 'save_tmpl_files' line
 	 */
 	$env_config['save_tmpl_files']           = 'y';
 	// $env_config['save_tmpl_files']           = (ENV == 'prod') ? 'n' : 'y';
-	$env_config['hidden_template_indicator'] = '_'; 
+	$env_config['hidden_template_indicator'] = '_';
 
 
 
 	/**
 	 * Debugging settings
-	 * 
+	 *
 	 * These settings are helpful to have in one place
 	 * for debugging purposes
 	 */
@@ -136,7 +136,7 @@ if (isset($config))
 	$env_config['template_debugging']   = (ENV_DEBUG) ? 'y' : 'n' ;
 	/**
 	 * Set debug to '2' if we're in dev mode, otherwise just '1'
-	 * 
+	 *
 	 * 0: no PHP/SQL errors shown
 	 * 1: Errors shown to Super Admins
 	 * 2: Errors shown to everyone
@@ -147,7 +147,7 @@ if (isset($config))
 
 	/**
 	 * Tracking & Performance settings
-	 * 
+	 *
 	 * These settings may impact what happens on certain page loads
 	 * and turning them off could help with performance in general
 	 */
@@ -166,7 +166,7 @@ if (isset($config))
 	/**
 	 * 3rd Party Add-on config items as needed
 	 */
-	
+
 
 
 
@@ -192,7 +192,7 @@ if (isset($config))
 	/**
 	 * Load our environment-specific config file
 	 * May contain override values from similar above settings
-	 * 
+	 *
 	 * @see config/config.local.php
 	 * @see config/config.dev.php
 	 * @see config/config.stage.php
@@ -205,7 +205,7 @@ if (isset($config))
 
 	/**
 	 * Setup our template-level global variables
-	 * 
+	 *
 	 * As inspired by NSM Bootstrap Config
 	 * @see http://ee-garage.com/nsm-config-bootstrap
 	 */
@@ -214,7 +214,7 @@ if (isset($config))
 	{
 		$assign_to_config['global_vars'] = array();
 	}
-	
+
 	// Start our array with environment variables. This gives us {global:env} and {global:env_full} tags for our templates.
 	$master_global = array(
 		'global:env'      => ENV,
@@ -225,17 +225,17 @@ if (isset($config))
 
 	/**
 	 * Merge arrays to form final datasets
-	 * 
+	 *
 	 * We've created our base config and global key->value stores
 	 * We've also included the environment-specific arrays now
 	 * Here we'll merge the arrays to create our final array dataset which
 	 * respects "most recent data" first if any keys are duplicated
-	 * 
+	 *
 	 * This is how our environment settings are "king" over any defaults
 	 */
 	$assign_to_config['global_vars'] = array_merge($assign_to_config['global_vars'], $master_global, $env_global); // global var arrays
 	$config = array_merge($config, $env_config); // config setting arrays
-	
+
 }
 // End if (isset($config)) {}
 

--- a/config/config.prod.php
+++ b/config/config.prod.php
@@ -2,11 +2,11 @@
 
 /**
  * Production config overrides & db credentials
- * 
+ *
  * Our database credentials and any environment-specific overrides
- * 
+ *
  * @package    Focus Lab Master Config
- * @version    2.1.1
+ * @version    2.2.0
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
  */
 

--- a/config/config.stage.php
+++ b/config/config.stage.php
@@ -2,11 +2,11 @@
 
 /**
  * Staging config overrides & db credentials
- * 
+ *
  * Our database credentials and any environment-specific overrides
- * 
+ *
  * @package    Focus Lab Master Config
- * @version    2.1.1
+ * @version    2.2.0
  * @author     Focus Lab, LLC <dev@focuslabllc.com>
  */
 

--- a/readme.textile
+++ b/readme.textile
@@ -35,13 +35,16 @@ h3. Environment Declaration
 
 This file is the starting point of your environment setup. Based on the @HTTP_HOST@ variable in PHP we define the environment (this may change if you're using a load balance environment or EE's MSM module). This is handled in the @config.env.php@ file.
 
+You should *never* use @HTTP_HOST@ to define the actual domain of your site. Someone could use a header to change the value of @HTTP_HOST@ which would cause *all* of your URLs to go to a domain of their choosing. For more details, take a look at "this article":http://carlos.bueno.org/2008/06/host-header-injection.html.
+
 We approach the environment from the top down. We define all environments based on the domain and then set our default to "local" which allows our local developers to use whatever domain they choose (eg: mysite.dev, mysite.local, etc).
 
-Three constants are defined in our environment declaration file. They are:
+Four constants are defined in our environment declaration file. They are:
 
 * @ENV@
 * @ENV_FULL@
 * @ENV_DEBUG@
+* @ENV_DOMAIN@
 
 *@ENV@*
 
@@ -54,6 +57,10 @@ This is the full name of your environment. There are no requirements on this val
 *@ENV_DEBUG@*
 
 This is our boolean debug flag used frequently in our master config file. It allows us to keep debug settings "on" in specific environments. You can see how this is used in the master config file.
+
+*@ENV_DOMAIN@*
+
+This is the domain of your environment. It must contain the domain (e.g. www.example.com or staging.example.com) for your environment.
 
 h3. Master Config file
 


### PR DESCRIPTION
Since `HTTP_HOST` is [insecure](http://carlos.bueno.org/2008/06/host-header-injection.html), I've replaced it's use in `config.master.php` with a constant (`ENV_DOMAIN`) that's set in `config.env.php` based on the URL of the current environment. Ultimately, every domain must be set ahead of time so you know you're only using domains that you've approved.
